### PR TITLE
Module Weapon & Projectile Effects, Build HUD Fixes

### DIFF
--- a/Assets/GameData/Modules/module_proton_accelerator.asset
+++ b/Assets/GameData/Modules/module_proton_accelerator.asset
@@ -69,7 +69,11 @@ MonoBehaviour:
   background: {fileID: 21300008, guid: f6e0548d6f5a7064eaef1aae7c62514f, type: 3}
   description: Increased rate of fire
   size: 1
-  hasDefaultShipEffects: 1
+  hasShipEffects: 1
   shipEffects:
   - Level: 0
     EffectCollection: {fileID: 11400000, guid: b5a7799e420c4cf40bbcdbe0932ea6da, type: 2}
+  hasWeaponEffects: 0
+  weaponEffects: []
+  hasProjectileEffects: 0
+  projectileEffects: []

--- a/Assets/GameData/Modules/module_scrap.asset
+++ b/Assets/GameData/Modules/module_scrap.asset
@@ -69,5 +69,11 @@ MonoBehaviour:
   background: {fileID: 21300000, guid: f6e0548d6f5a7064eaef1aae7c62514f, type: 3}
   description: Collects Scrap
   size: 0
-  hasDefaultShipEffects: 0
+  hasShipEffects: 0
   shipEffects: []
+  hasWeaponEffects: 0
+  weaponEffects: []
+  hasProjectileEffects: 1
+  projectileEffects:
+  - Level: 3
+    EffectCollection: {fileID: 11400000, guid: 922abbef8ae38a54da55d963727be36a, type: 2}

--- a/Assets/Prefabs/Ships/Player Ships/player_medium_ship.prefab
+++ b/Assets/Prefabs/Ships/Player Ships/player_medium_ship.prefab
@@ -306,11 +306,7 @@ MonoBehaviour:
   isWeapon: 1
   hasDefaultModule: 1
   module: {fileID: 11400000, guid: 4823060fc78e6b74fbcc700c5aac91e9, type: 2}
-  moduleEffects:
-  - Level: 1
-    EffectCollection: {fileID: 11400000, guid: 4f42264387040ca449cb3add683feec6, type: 2}
-  - Level: 0
-    EffectCollection: {fileID: 11400000, guid: e3f09900eaa4ffc48af44e95219ce278, type: 2}
+  moduleEffects: []
   projectileEffects: []
 --- !u!1 &6803760354808902825
 GameObject:
@@ -359,16 +355,8 @@ MonoBehaviour:
   isWeapon: 1
   hasDefaultModule: 1
   module: {fileID: 11400000, guid: 4823060fc78e6b74fbcc700c5aac91e9, type: 2}
-  moduleEffects:
-  - Level: 0
-    EffectCollection: {fileID: 11400000, guid: e3f09900eaa4ffc48af44e95219ce278, type: 2}
-  - Level: 1
-    EffectCollection: {fileID: 11400000, guid: df06f026a5531b3439a3e0d8dd20f7b3, type: 2}
-  projectileEffects:
-  - Level: 3
-    EffectCollection: {fileID: 11400000, guid: 922abbef8ae38a54da55d963727be36a, type: 2}
-  - Level: 1
-    EffectCollection: {fileID: 11400000, guid: c3d1c7991029b6743829040b433016b6, type: 2}
+  moduleEffects: []
+  projectileEffects: []
 --- !u!1 &8593195112231694218
 GameObject:
   m_ObjectHideFlags: 0

--- a/Assets/Scenes/Main.unity
+++ b/Assets/Scenes/Main.unity
@@ -5055,7 +5055,7 @@ Transform:
   m_LocalScale: {x: 1, y: 1, z: 1}
   m_Children: []
   m_Father: {fileID: 0}
-  m_RootOrder: 8
+  m_RootOrder: 7
   m_LocalEulerAnglesHint: {x: -90, y: 0, z: 0}
 --- !u!1 &926340479
 GameObject:
@@ -5258,7 +5258,7 @@ Transform:
   m_LocalScale: {x: 1, y: 1, z: 1}
   m_Children: []
   m_Father: {fileID: 0}
-  m_RootOrder: 6
+  m_RootOrder: 5
   m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
 --- !u!114 &1365698838 stripped
 MonoBehaviour:
@@ -5401,127 +5401,6 @@ Rigidbody2D:
   m_SleepingMode: 1
   m_CollisionDetection: 0
   m_Constraints: 0
---- !u!1001 &1780820854
-PrefabInstance:
-  m_ObjectHideFlags: 0
-  serializedVersion: 2
-  m_Modification:
-    m_TransformParent: {fileID: 0}
-    m_Modifications:
-    - target: {fileID: 3667696406609837293, guid: fd7c17f1fbc086f4eb86a05e4794993d, type: 3}
-      propertyPath: m_RootOrder
-      value: 3
-      objectReference: {fileID: 0}
-    - target: {fileID: 3667696406609837293, guid: fd7c17f1fbc086f4eb86a05e4794993d, type: 3}
-      propertyPath: m_LocalPosition.x
-      value: 0
-      objectReference: {fileID: 0}
-    - target: {fileID: 3667696406609837293, guid: fd7c17f1fbc086f4eb86a05e4794993d, type: 3}
-      propertyPath: m_LocalPosition.y
-      value: 0
-      objectReference: {fileID: 0}
-    - target: {fileID: 3667696406609837293, guid: fd7c17f1fbc086f4eb86a05e4794993d, type: 3}
-      propertyPath: m_LocalPosition.z
-      value: 0
-      objectReference: {fileID: 0}
-    - target: {fileID: 3667696406609837293, guid: fd7c17f1fbc086f4eb86a05e4794993d, type: 3}
-      propertyPath: m_LocalRotation.w
-      value: 1
-      objectReference: {fileID: 0}
-    - target: {fileID: 3667696406609837293, guid: fd7c17f1fbc086f4eb86a05e4794993d, type: 3}
-      propertyPath: m_LocalRotation.x
-      value: 0
-      objectReference: {fileID: 0}
-    - target: {fileID: 3667696406609837293, guid: fd7c17f1fbc086f4eb86a05e4794993d, type: 3}
-      propertyPath: m_LocalRotation.y
-      value: 0
-      objectReference: {fileID: 0}
-    - target: {fileID: 3667696406609837293, guid: fd7c17f1fbc086f4eb86a05e4794993d, type: 3}
-      propertyPath: m_LocalRotation.z
-      value: 0
-      objectReference: {fileID: 0}
-    - target: {fileID: 3667696406609837293, guid: fd7c17f1fbc086f4eb86a05e4794993d, type: 3}
-      propertyPath: m_LocalEulerAnglesHint.x
-      value: 0
-      objectReference: {fileID: 0}
-    - target: {fileID: 3667696406609837293, guid: fd7c17f1fbc086f4eb86a05e4794993d, type: 3}
-      propertyPath: m_LocalEulerAnglesHint.y
-      value: 0
-      objectReference: {fileID: 0}
-    - target: {fileID: 3667696406609837293, guid: fd7c17f1fbc086f4eb86a05e4794993d, type: 3}
-      propertyPath: m_LocalEulerAnglesHint.z
-      value: 0
-      objectReference: {fileID: 0}
-    - target: {fileID: 3667696406609837294, guid: fd7c17f1fbc086f4eb86a05e4794993d, type: 3}
-      propertyPath: m_Name
-      value: ui_console
-      objectReference: {fileID: 0}
-    - target: {fileID: 3667696407076179152, guid: fd7c17f1fbc086f4eb86a05e4794993d, type: 3}
-      propertyPath: m_AnchoredPosition.y
-      value: -18
-      objectReference: {fileID: 0}
-    - target: {fileID: 4178895634782722161, guid: fd7c17f1fbc086f4eb86a05e4794993d, type: 3}
-      propertyPath: m_AnchorMax.x
-      value: 0.5
-      objectReference: {fileID: 0}
-    - target: {fileID: 4178895634782722161, guid: fd7c17f1fbc086f4eb86a05e4794993d, type: 3}
-      propertyPath: m_AnchorMax.y
-      value: 0.5
-      objectReference: {fileID: 0}
-    - target: {fileID: 4178895634782722161, guid: fd7c17f1fbc086f4eb86a05e4794993d, type: 3}
-      propertyPath: m_AnchorMin.x
-      value: 0.5
-      objectReference: {fileID: 0}
-    - target: {fileID: 4178895634782722161, guid: fd7c17f1fbc086f4eb86a05e4794993d, type: 3}
-      propertyPath: m_AnchorMin.y
-      value: 0.5
-      objectReference: {fileID: 0}
-    - target: {fileID: 4178895634782722161, guid: fd7c17f1fbc086f4eb86a05e4794993d, type: 3}
-      propertyPath: m_SizeDelta.x
-      value: 1920
-      objectReference: {fileID: 0}
-    - target: {fileID: 4178895634782722161, guid: fd7c17f1fbc086f4eb86a05e4794993d, type: 3}
-      propertyPath: m_SizeDelta.y
-      value: 1080
-      objectReference: {fileID: 0}
-    - target: {fileID: 4178895634782722161, guid: fd7c17f1fbc086f4eb86a05e4794993d, type: 3}
-      propertyPath: m_LocalScale.x
-      value: 1
-      objectReference: {fileID: 0}
-    - target: {fileID: 4178895634782722161, guid: fd7c17f1fbc086f4eb86a05e4794993d, type: 3}
-      propertyPath: m_LocalScale.y
-      value: 1
-      objectReference: {fileID: 0}
-    - target: {fileID: 4178895634782722161, guid: fd7c17f1fbc086f4eb86a05e4794993d, type: 3}
-      propertyPath: m_LocalScale.z
-      value: 1
-      objectReference: {fileID: 0}
-    - target: {fileID: 4178895634782722161, guid: fd7c17f1fbc086f4eb86a05e4794993d, type: 3}
-      propertyPath: m_AnchoredPosition.x
-      value: 0
-      objectReference: {fileID: 0}
-    - target: {fileID: 4178895634782722161, guid: fd7c17f1fbc086f4eb86a05e4794993d, type: 3}
-      propertyPath: m_AnchoredPosition.y
-      value: 0
-      objectReference: {fileID: 0}
-    - target: {fileID: 4262880646223294123, guid: fd7c17f1fbc086f4eb86a05e4794993d, type: 3}
-      propertyPath: m_AnchoredPosition.y
-      value: -15.185059
-      objectReference: {fileID: 0}
-    - target: {fileID: 4944705786220820127, guid: fd7c17f1fbc086f4eb86a05e4794993d, type: 3}
-      propertyPath: m_Material
-      value: 
-      objectReference: {fileID: 2100000, guid: a801042073828374cacde9f18e94601a, type: 2}
-    - target: {fileID: 4944705786220820127, guid: fd7c17f1fbc086f4eb86a05e4794993d, type: 3}
-      propertyPath: m_UVRect.x
-      value: 0
-      objectReference: {fileID: 0}
-    - target: {fileID: 4944705786220820127, guid: fd7c17f1fbc086f4eb86a05e4794993d, type: 3}
-      propertyPath: m_UVRect.width
-      value: 1
-      objectReference: {fileID: 0}
-    m_RemovedComponents: []
-  m_SourcePrefab: {fileID: 100100000, guid: fd7c17f1fbc086f4eb86a05e4794993d, type: 3}
 --- !u!1 &1843779020
 GameObject:
   m_ObjectHideFlags: 0
@@ -5647,7 +5526,7 @@ Transform:
   - {fileID: 926340483}
   - {fileID: 327393922}
   m_Father: {fileID: 0}
-  m_RootOrder: 7
+  m_RootOrder: 6
   m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
 --- !u!1 &1971339495
 GameObject:
@@ -6030,7 +5909,7 @@ PrefabInstance:
       objectReference: {fileID: 0}
     - target: {fileID: 5641295164953991232, guid: 3873a34f86c4ca5439c25133c6908095, type: 3}
       propertyPath: m_RootOrder
-      value: 5
+      value: 4
       objectReference: {fileID: 0}
     - target: {fileID: 5641295164953991232, guid: 3873a34f86c4ca5439c25133c6908095, type: 3}
       propertyPath: m_AnchorMax.x
@@ -6151,7 +6030,7 @@ PrefabInstance:
       objectReference: {fileID: 0}
     - target: {fileID: 8531167039024123504, guid: d2172ba3cb7fc8a4785379e88f03d366, type: 3}
       propertyPath: m_RootOrder
-      value: 4
+      value: 3
       objectReference: {fileID: 0}
     - target: {fileID: 8531167039024123504, guid: d2172ba3cb7fc8a4785379e88f03d366, type: 3}
       propertyPath: m_LocalPosition.x

--- a/Assets/Scenes/SampleSceneLightingSettings.lighting
+++ b/Assets/Scenes/SampleSceneLightingSettings.lighting
@@ -7,8 +7,8 @@ LightingSettings:
   m_PrefabInstance: {fileID: 0}
   m_PrefabAsset: {fileID: 0}
   m_Name: SampleSceneLightingSettings
-  serializedVersion: 2
-  m_GIWorkflowMode: 0
+  serializedVersion: 3
+  m_GIWorkflowMode: 1
   m_EnableBakedLightmaps: 1
   m_EnableRealtimeLightmaps: 0
   m_RealtimeEnvironmentLighting: 0
@@ -29,7 +29,7 @@ LightingSettings:
   m_MixedBakeMode: 0
   m_LightmapsBakeMode: 1
   m_FilterMode: 1
-  m_LightmapParameters: {fileID: 0}
+  m_LightmapParameters: {fileID: 15204, guid: 0000000000000000f000000000000000, type: 0}
   m_ExportTrainingData: 0
   m_TrainingDataDestination: TrainingData
   m_RealtimeResolution: 2
@@ -46,7 +46,7 @@ LightingSettings:
   m_PVREnvironmentReferencePointCount: 2048
   m_LightProbeSampleCountMultiplier: 4
   m_PVRBounces: 2
-  m_PVRRussianRouletteStartBounce: 2
+  m_PVRMinBounces: 1
   m_PVREnvironmentMIS: 0
   m_PVRFilteringMode: 1
   m_PVRDenoiserTypeDirect: 0

--- a/Assets/Scripts/Game/Entities/WeaponEntity.cs
+++ b/Assets/Scripts/Game/Entities/WeaponEntity.cs
@@ -18,9 +18,9 @@ namespace Celeritas.Game.Entities
 		private float maxCharge = 10.0f;
 
 		/// <summary>
-		/// Get the effect manager for the weapons on this entity.
+		/// Get the effect manager for the projectiles on this entity.
 		/// </summary>
-		public EffectManager WeaponEffects { get; private set; }
+		public EffectManager ProjectileEffects { get; private set; }
 
 		/// <summary>
 		/// The attatched weapon data.
@@ -44,7 +44,7 @@ namespace Celeritas.Game.Entities
 			rateOfFire = WeaponData.RateOfFire;
 			maxCharge = WeaponData.MaxCharge;
 
-			WeaponEffects = new EffectManager(this, SystemTargets.Projectile);
+			ProjectileEffects = new EffectManager(this, SystemTargets.Projectile);
 
 			base.Initalize(data, owner, effects, forceIsPlayer);
 		}
@@ -100,7 +100,7 @@ namespace Celeritas.Game.Entities
 
 		protected virtual void Fire()
 		{
-			var projectile = EntityDataManager.InstantiateEntity<ProjectileEntity>(WeaponData.Projectile, this, WeaponEffects.EffectWrapperCopy);
+			var projectile = EntityDataManager.InstantiateEntity<ProjectileEntity>(WeaponData.Projectile, this, ProjectileEffects.EffectWrapperCopy);
 			projectile.transform.CopyTransform(projectileSpawn);
 			EntityEffects.EntityFired(projectile);
 		}

--- a/Assets/Scripts/Game/Module.cs
+++ b/Assets/Scripts/Game/Module.cs
@@ -93,12 +93,24 @@ namespace Celeritas.Game
 
 			if (AttatchedModule is WeaponEntity weapon)
 			{
-				weapon.WeaponEffects.AddEffectRange(projectileEffects);
+				weapon.ProjectileEffects.AddEffectRange(projectileEffects);
 			}
 
-			if (module.HasDefaultShipEffects)
+			if (module.HasShipEffects)
 			{
 				Ship.EntityEffects.AddEffectRange(module.ShipEffects);
+			}
+
+			if (module.HasWeaponEffects || module.HasProjectileEffects)
+			{
+				foreach (var entity in Ship.WeaponEntities)
+				{
+					if (module.HasWeaponEffects)
+						entity.EntityEffects.AddEffectRange(module.WeaponEffects);
+
+					if (module.HasProjectileEffects)
+						entity.ProjectileEffects.AddEffectRange(module.ProjectileEffects);
+				}
 			}
 		}
 
@@ -106,10 +118,23 @@ namespace Celeritas.Game
 		{
 			if (AttatchedModule != null)
 			{
-				if (AttatchedModule.ModuleData.HasDefaultShipEffects)
+				if (AttatchedModule.ModuleData.HasShipEffects)
 				{
 					Ship.EntityEffects.RemoveEffectRange(AttatchedModule.ModuleData.ShipEffects);
 				}
+
+				if (AttatchedModule.ModuleData.HasWeaponEffects || AttatchedModule.ModuleData.HasProjectileEffects)
+				{
+					foreach (var entity in Ship.WeaponEntities)
+					{
+						if (AttatchedModule.ModuleData.HasWeaponEffects)
+							entity.EntityEffects.RemoveEffectRange(AttatchedModule.ModuleData.WeaponEffects);
+
+						if (AttatchedModule.ModuleData.HasProjectileEffects)
+							entity.ProjectileEffects.RemoveEffectRange(AttatchedModule.ModuleData.ProjectileEffects);
+					}
+				}
+
 				Destroy(AttatchedModule.gameObject);
 
 				AttatchedModule = null;

--- a/Assets/Scripts/Game/Module.cs
+++ b/Assets/Scripts/Game/Module.cs
@@ -114,6 +114,9 @@ namespace Celeritas.Game
 			}
 		}
 
+		/// <summary>
+		/// Remove the currently attatched module entity from this module.
+		/// </summary>
 		public void RemoveModule()
 		{
 			if (AttatchedModule != null)

--- a/Assets/Scripts/Game/PlayerSpawner.cs
+++ b/Assets/Scripts/Game/PlayerSpawner.cs
@@ -15,6 +15,7 @@ namespace Celeritas.Game
 		[PreviewField]
 		[SerializeField, Title("Settings")]
 		private ShipData ship;
+
 		[SerializeField]
 		private ActionData action;
 

--- a/Assets/Scripts/Scriptables/Data/AsteroidData.cs
+++ b/Assets/Scripts/Scriptables/Data/AsteroidData.cs
@@ -1,10 +1,4 @@
 ﻿using Celeritas.Scriptables;
-using Sirenix.OdinInspector;
-using System;
-using System.Collections.Generic;
-using System.Linq;
-using System.Text;
-using System.Threading.Tasks;
 using UnityEngine;
 
 namespace Assets.Scripts.Scriptables.Data

--- a/Assets/Scripts/Scriptables/Data/LootData.cs
+++ b/Assets/Scripts/Scriptables/Data/LootData.cs
@@ -1,9 +1,4 @@
 ﻿using Celeritas.Scriptables;
-using System;
-using System.Collections.Generic;
-using System.Linq;
-using System.Text;
-using System.Threading.Tasks;
 using UnityEngine;
 using static Celeritas.Game.Entities.LootController;
 

--- a/Assets/Scripts/Scriptables/ModuleData.cs
+++ b/Assets/Scripts/Scriptables/ModuleData.cs
@@ -60,24 +60,54 @@ namespace Celeritas.Scriptables
 
 		public bool[,] ModuleLayout { get => moduleLayout;}
 
+		/// <summary>
+		/// The icon for the module.
+		/// </summary>
 		public Sprite Icon { get => icon; }
 
+		/// <summary>
+		/// The background for the module.
+		/// </summary>
 		public Sprite Background { get => background; }
 
+		/// <summary>
+		/// The description for the module.
+		/// </summary>
 		public string Description { get => description; }
 
+		/// <summary>
+		/// The size of this module.
+		/// </summary>
 		public ModuleSize ModuleSize { get => size; }
 
+		/// <summary>
+		/// Does this module add effects to the ship entity.
+		/// </summary>
 		public bool HasShipEffects { get => hasShipEffects; }
 
+		/// <summary>
+		/// The effects to add to the ship entity, if used.
+		/// </summary>
 		public EffectWrapper[] ShipEffects { get => shipEffects; }
 
+		/// <summary>
+		/// Does this module add effects to the ships weapon entities.
+		/// </summary>
 		public bool HasWeaponEffects { get => hasWeaponEffects; }
 
+		/// <summary>
+		/// The effects to add to the ships weapon entities, if used.
+		/// </summary>
 		public EffectWrapper[] WeaponEffects { get => weaponEffects; }
 
+		/// <summary>
+		/// Does this module add effects to the ships projectile entities.
+		/// </summary>
 		public bool HasProjectileEffects { get => hasProjectileEffects; }
 
+		/// <summary>
+		/// The effects to add to the ships projectile entities, if used.
+		/// </summary>
 		public EffectWrapper[] ProjectileEffects { get => projectileEffects; }
 
 		public override string Tooltip => $"A <color=\"orange\">{size}</color> module.";

--- a/Assets/Scripts/Scriptables/ModuleData.cs
+++ b/Assets/Scripts/Scriptables/ModuleData.cs
@@ -35,10 +35,22 @@ namespace Celeritas.Scriptables
 		private ModuleSize size;
 
 		[SerializeField, Title("Ship Effects")]
-		private bool hasDefaultShipEffects;
+		private bool hasShipEffects;
 
-		[SerializeField, ShowIf(nameof(hasDefaultShipEffects))]
+		[SerializeField, ShowIf(nameof(hasShipEffects))]
 		private EffectWrapper[] shipEffects;
+
+		[SerializeField, Title("Weapon Effects")]
+		private bool hasWeaponEffects;
+
+		[SerializeField, ShowIf(nameof(hasWeaponEffects))]
+		private EffectWrapper[] weaponEffects;
+
+		[SerializeField, Title("Projectile Effects")]
+		private bool hasProjectileEffects;
+
+		[SerializeField, ShowIf(nameof(hasProjectileEffects))]
+		private EffectWrapper[] projectileEffects;
 
 		[SerializeField, Title("Module Layout")]
 		[TableMatrix(SquareCells = true, DrawElementMethod = nameof(OnLayoutDraw))]
@@ -56,9 +68,17 @@ namespace Celeritas.Scriptables
 
 		public ModuleSize ModuleSize { get => size; }
 
-		public bool HasDefaultShipEffects { get => hasDefaultShipEffects; }
+		public bool HasShipEffects { get => hasShipEffects; }
 
 		public EffectWrapper[] ShipEffects { get => shipEffects; }
+
+		public bool HasWeaponEffects { get => hasWeaponEffects; }
+
+		public EffectWrapper[] WeaponEffects { get => weaponEffects; }
+
+		public bool HasProjectileEffects { get => hasProjectileEffects; }
+
+		public EffectWrapper[] ProjectileEffects { get => projectileEffects; }
 
 		public override string Tooltip => $"A <color=\"orange\">{size}</color> module.";
 

--- a/Assets/Scripts/UI/BuildHUD.cs
+++ b/Assets/Scripts/UI/BuildHUD.cs
@@ -88,7 +88,6 @@ namespace Celeritas.UI
 						}
 					});
 
-
 					if (hull.HullData.HullModules[grid.x, grid.y] == null && hull.Modules[grid.x, grid.y].HasModuleAttatched == false && isOverModule != true)
 					{
 						placeObject.SetActive(true);
@@ -106,7 +105,7 @@ namespace Celeritas.UI
 				}
 				else
 				{
-					placeObject.SetActive(true);
+					placeObject.SetActive(false);
 					placingMaterial.color = new Color(1, 0, 0);
 					canPlace = false;
 				}
@@ -155,6 +154,7 @@ namespace Celeritas.UI
 					hull.Modules[grid.x, grid.y].RemoveModule();
 					hull.HullData.HullModuleOrigins[grid.x, grid.y] = null;
 					hull.GenerateModuleWalls();
+					PlayerController.Instance.PlayerShipEntity.Inventory.Add(dragging);
 				}
 			}
 		}
@@ -173,9 +173,6 @@ namespace Celeritas.UI
 			else if (dragging != null)
 			{
 				inventory.AddInventoryItem(dragging);
-
-				var ship = PlayerController.Instance.PlayerShipEntity;
-				ship.Inventory.Add(dragging);
 			}
 
 			canPlace = false;


### PR DESCRIPTION
## Summary
This PR adds the functionality for modules to add effects to the player ships weapons and projectiles, effect collections can be controlled in the modules data file.

This also includes improvements for the Build HUD, the mesh is never visible unless it can be placed and a bug was fixed where it was possible to duplicate items in your inventory if you closed the Build HUD in a specific way while holding an item.

## Linked Issues
_NA_

## Screenshots (optional)
_NA_