### PR TITLE
Basic wave rebalance

### DIFF
--- a/Assets/Prefabs/Ships/AI Ships/medium_ship.prefab
+++ b/Assets/Prefabs/Ships/AI Ships/medium_ship.prefab
@@ -172,7 +172,7 @@ MonoBehaviour:
     maxValue: 0
     currentValue: 0
   lootConfig:
-    gain: 1
+    gain: 10
     isBoss: 0
   dropType: 0
   engineEffects: []

--- a/Assets/Prefabs/Ships/AI Ships/small_fast_ship.prefab
+++ b/Assets/Prefabs/Ships/AI Ships/small_fast_ship.prefab
@@ -28,7 +28,7 @@ Transform:
   m_GameObject: {fileID: 2516558698829045457}
   m_LocalRotation: {x: 0, y: 0, z: 0, w: 1}
   m_LocalPosition: {x: 0, y: 0, z: 0}
-  m_LocalScale: {x: 1, y: 1, z: 1}
+  m_LocalScale: {x: 3, y: 3, z: 3}
   m_Children:
   - {fileID: 2516558699759650294}
   - {fileID: 2489298676919761349}
@@ -73,7 +73,7 @@ MonoBehaviour:
     maxValue: 0
     currentValue: 0
   lootConfig:
-    gain: 100
+    gain: 1
     isBoss: 0
   dropType: 0
   engineEffects:

--- a/Assets/Scripts/Game/Waves/WaveManager.cs
+++ b/Assets/Scripts/Game/Waves/WaveManager.cs
@@ -17,7 +17,7 @@ namespace Celeritas.Game
 		protected override void Awake()
 		{
 			waveIndex = 0;
-			WaveLootValues = new List<int>() { 5, 7, 10 };
+			WaveLootValues = new List<int>() { 5, 15 };
 		}
 
 		[SerializeField]
@@ -37,7 +37,8 @@ namespace Celeritas.Game
 		public void StartWave()
 		{
 			WaveActive = true;
-			waveIndex = (int)Mathf.Repeat(waveIndex, data.Length - 1);
+			//waveIndex = (int)Mathf.Repeat(waveIndex, data.Length - 1);
+			Debug.Log("WaveIndex: " + waveIndex);
 			var wave = data[waveIndex];
 			ships[wave] = new List<ShipEntity>();
 
@@ -53,6 +54,10 @@ namespace Celeritas.Game
 
 			OnWaveStarted?.Invoke();
 			waveIndex++;
+			if (waveIndex >= data.Length)
+			{
+				waveIndex = 0;
+			}
 		}
 
 		private Dictionary<WaveData, List<ShipEntity>> ships = new Dictionary<WaveData, List<ShipEntity>>();


### PR DESCRIPTION
## Summary
Rebalances waves so they a) pull from both ship lists, and b) generate a roughly appropriate number of ships. This involves messing with the ships' drop rates, so don't be surprised if you get less modules!

Additionally, increases the size of the tiny ship x3.  Still small, but easier to hit!
