### PR TITLE
Added Ship Hull Strength Module

### DIFF
--- a/Assets/GameData/Effect Collection/effect_health_increase.asset
+++ b/Assets/GameData/Effect Collection/effect_health_increase.asset
@@ -1,0 +1,19 @@
+%YAML 1.1
+%TAG !u! tag:unity3d.com,2011:
+--- !u!114 &11400000
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 0}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: 3ee0d4ee51750af45b7430210d4a5dbd, type: 3}
+  m_Name: effect_health_increase
+  m_EditorClassIdentifier: 
+  title: Health Booster
+  targets: 4
+  stacks: 1
+  systems:
+  - {fileID: 11400000, guid: 845da902440dbce49b78ed8f9b5effd0, type: 2}

--- a/Assets/GameData/Effect Collection/effect_health_increase.asset.meta
+++ b/Assets/GameData/Effect Collection/effect_health_increase.asset.meta
@@ -1,0 +1,8 @@
+fileFormatVersion: 2
+guid: f653bdfa200d5104eaf84373c9f27ad8
+NativeFormatImporter:
+  externalObjects: {}
+  mainObjectFileID: 11400000
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Assets/GameData/Modules/module_health_increase.asset
+++ b/Assets/GameData/Modules/module_health_increase.asset
@@ -1,0 +1,117 @@
+%YAML 1.1
+%TAG !u! tag:unity3d.com,2011:
+--- !u!114 &11400000
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 0}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: e81afd5e3fc38f04a85d551b5ddbf13e, type: 3}
+  m_Name: module_health_increase
+  m_EditorClassIdentifier: 
+  serializationData:
+    SerializedFormat: 2
+    SerializedBytes: 
+    ReferencedUnityObjects: []
+    SerializedBytesString: 
+    Prefab: {fileID: 0}
+    PrefabModificationsReferencedUnityObjects: []
+    PrefabModifications: []
+    SerializationNodes:
+    - Name: moduleLayout
+      Entry: 7
+      Data: 0|System.Boolean[,], mscorlib
+    - Name: 
+      Entry: 12
+      Data: 9
+    - Name: ranks
+      Entry: 1
+      Data: 3|3
+    - Name: 
+      Entry: 5
+      Data: true
+    - Name: 
+      Entry: 5
+      Data: false
+    - Name: 
+      Entry: 5
+      Data: false
+    - Name: 
+      Entry: 5
+      Data: false
+    - Name: 
+      Entry: 5
+      Data: false
+    - Name: 
+      Entry: 5
+      Data: false
+    - Name: 
+      Entry: 5
+      Data: false
+    - Name: 
+      Entry: 5
+      Data: false
+    - Name: 
+      Entry: 5
+      Data: false
+    - Name: 
+      Entry: 13
+      Data: 
+    - Name: 
+      Entry: 8
+      Data: 
+    - Name: iconLayout
+      Entry: 7
+      Data: 1|System.Boolean[,], mscorlib
+    - Name: 
+      Entry: 12
+      Data: 9
+    - Name: ranks
+      Entry: 1
+      Data: 3|3
+    - Name: 
+      Entry: 5
+      Data: false
+    - Name: 
+      Entry: 5
+      Data: false
+    - Name: 
+      Entry: 5
+      Data: false
+    - Name: 
+      Entry: 5
+      Data: false
+    - Name: 
+      Entry: 5
+      Data: false
+    - Name: 
+      Entry: 5
+      Data: false
+    - Name: 
+      Entry: 5
+      Data: false
+    - Name: 
+      Entry: 5
+      Data: false
+    - Name: 
+      Entry: 5
+      Data: false
+    - Name: 
+      Entry: 13
+      Data: 
+    - Name: 
+      Entry: 8
+      Data: 
+  title: Health Booster
+  prefab: {fileID: 4878486589743009938, guid: bfedf127b367d9242aa64dcf160f3448, type: 3}
+  capacityHint: 1
+  useChunking: 0
+  size: 0
+  catagory: 1
+  rarity: 0
+  icon: {fileID: 21300000, guid: d49094c1f2b72d847855d707b28d36c9, type: 3}
+  description: Increases the maximum amount of health to withstand greater amounts
+    of enemy fire.

--- a/Assets/GameData/Modules/module_health_increase.asset.meta
+++ b/Assets/GameData/Modules/module_health_increase.asset.meta
@@ -1,0 +1,8 @@
+fileFormatVersion: 2
+guid: fe00e2d8392042046a32d37cf0e04c63
+NativeFormatImporter:
+  externalObjects: {}
+  mainObjectFileID: 11400000
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Assets/GameData/Systems/modifier_health_increase.asset
+++ b/Assets/GameData/Systems/modifier_health_increase.asset
@@ -1,0 +1,17 @@
+%YAML 1.1
+%TAG !u! tag:unity3d.com,2011:
+--- !u!114 &11400000
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 0}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: a484dd965beb522419eb1b5b812485c0, type: 3}
+  m_Name: modifier_health_increase
+  m_EditorClassIdentifier: 
+  title: Health Booster
+  amount: 33
+  amountExtraPerLevel: 33

--- a/Assets/GameData/Systems/modifier_health_increase.asset.meta
+++ b/Assets/GameData/Systems/modifier_health_increase.asset.meta
@@ -1,0 +1,8 @@
+fileFormatVersion: 2
+guid: 845da902440dbce49b78ed8f9b5effd0
+NativeFormatImporter:
+  externalObjects: {}
+  mainObjectFileID: 11400000
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Assets/Prefabs/Modules/module_health_increase.prefab
+++ b/Assets/Prefabs/Modules/module_health_increase.prefab
@@ -1,0 +1,233 @@
+%YAML 1.1
+%TAG !u! tag:unity3d.com,2011:
+--- !u!1 &2688834259425347212
+GameObject:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  serializedVersion: 6
+  m_Component:
+  - component: {fileID: 8787284566601216313}
+  m_Layer: 0
+  m_Name: IconGroup
+  m_TagString: Untagged
+  m_Icon: {fileID: 0}
+  m_NavMeshLayer: 0
+  m_StaticEditorFlags: 0
+  m_IsActive: 1
+--- !u!4 &8787284566601216313
+Transform:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 2688834259425347212}
+  m_LocalRotation: {x: -0, y: -0, z: -0, w: 1}
+  m_LocalPosition: {x: 0, y: 0, z: 0}
+  m_LocalScale: {x: 1, y: 1, z: 1}
+  m_Children: []
+  m_Father: {fileID: 4245375790672528523}
+  m_RootOrder: 1
+  m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
+--- !u!1 &2806959056104796458
+GameObject:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  serializedVersion: 6
+  m_Component:
+  - component: {fileID: 1259774824615474666}
+  - component: {fileID: 4777281293409026308}
+  - component: {fileID: 4035689934436959314}
+  m_Layer: 0
+  m_Name: module_floor(Clone)
+  m_TagString: Untagged
+  m_Icon: {fileID: 0}
+  m_NavMeshLayer: 0
+  m_StaticEditorFlags: 0
+  m_IsActive: 1
+--- !u!4 &1259774824615474666
+Transform:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 2806959056104796458}
+  m_LocalRotation: {x: -0, y: -0, z: -0, w: 1}
+  m_LocalPosition: {x: 0, y: 0, z: 0}
+  m_LocalScale: {x: 1, y: 1, z: 0.04}
+  m_Children: []
+  m_Father: {fileID: 7784592585474095672}
+  m_RootOrder: 0
+  m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
+--- !u!23 &4777281293409026308
+MeshRenderer:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 2806959056104796458}
+  m_Enabled: 1
+  m_CastShadows: 1
+  m_ReceiveShadows: 1
+  m_DynamicOccludee: 1
+  m_MotionVectors: 1
+  m_LightProbeUsage: 1
+  m_ReflectionProbeUsage: 1
+  m_RayTracingMode: 2
+  m_RayTraceProcedural: 0
+  m_RenderingLayerMask: 1
+  m_RendererPriority: 0
+  m_Materials:
+  - {fileID: 2100000, guid: cbddbe6304d185748b49f4368ce8ab1c, type: 2}
+  m_StaticBatchInfo:
+    firstSubMesh: 0
+    subMeshCount: 0
+  m_StaticBatchRoot: {fileID: 0}
+  m_ProbeAnchor: {fileID: 0}
+  m_LightProbeVolumeOverride: {fileID: 0}
+  m_ScaleInLightmap: 1
+  m_ReceiveGI: 1
+  m_PreserveUVs: 0
+  m_IgnoreNormalsForChartDetection: 0
+  m_ImportantGI: 0
+  m_StitchLightmapSeams: 1
+  m_SelectedEditorRenderState: 3
+  m_MinimumChartSize: 4
+  m_AutoUVMaxDistance: 0.5
+  m_AutoUVMaxAngle: 89
+  m_LightmapParameters: {fileID: 0}
+  m_SortingLayerID: 0
+  m_SortingLayer: 0
+  m_SortingOrder: 0
+  m_AdditionalVertexStreams: {fileID: 0}
+--- !u!33 &4035689934436959314
+MeshFilter:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 2806959056104796458}
+  m_Mesh: {fileID: 10202, guid: 0000000000000000e000000000000000, type: 0}
+--- !u!1 &4878486589743009938
+GameObject:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  serializedVersion: 6
+  m_Component:
+  - component: {fileID: 4245375790672528523}
+  - component: {fileID: 6649836655241533041}
+  - component: {fileID: 5763187196993101604}
+  m_Layer: 0
+  m_Name: module_health_increase
+  m_TagString: Untagged
+  m_Icon: {fileID: 0}
+  m_NavMeshLayer: 0
+  m_StaticEditorFlags: 0
+  m_IsActive: 1
+--- !u!4 &4245375790672528523
+Transform:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 4878486589743009938}
+  m_LocalRotation: {x: 0, y: 0, z: 0, w: 1}
+  m_LocalPosition: {x: 0, y: 0, z: 0}
+  m_LocalScale: {x: 1, y: 1, z: 1}
+  m_Children:
+  - {fileID: 7784592585474095672}
+  - {fileID: 8787284566601216313}
+  m_Father: {fileID: 0}
+  m_RootOrder: 0
+  m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
+--- !u!114 &6649836655241533041
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 4878486589743009938}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: b3575df0d56f87c4db13bc0c4d95e6fb, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
+  serializationData:
+    SerializedFormat: 2
+    SerializedBytes: 
+    ReferencedUnityObjects: []
+    SerializedBytesString: 
+    Prefab: {fileID: 0}
+    PrefabModificationsReferencedUnityObjects: []
+    PrefabModifications: []
+    SerializationNodes: []
+  hasDefaultEffects: 0
+  defaultEffects: []
+  level: 0
+  hasShipEffects: 1
+  shipEffects:
+  - Level: 0
+    EffectCollection: {fileID: 11400000, guid: f653bdfa200d5104eaf84373c9f27ad8, type: 2}
+  hasShipWeaponEffects: 0
+  shipWeaponEffects: []
+  hasShipProjectileEffects: 0
+  shipProjectileEffects: []
+--- !u!114 &5763187196993101604
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 4878486589743009938}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: f31d3533757b1104cb68bb299645065d, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
+  serializationData:
+    SerializedFormat: 2
+    SerializedBytes: 
+    ReferencedUnityObjects: []
+    SerializedBytesString: 
+    Prefab: {fileID: 0}
+    PrefabModificationsReferencedUnityObjects: []
+    PrefabModifications: []
+    SerializationNodes: []
+  module: {fileID: 11400000, guid: fe00e2d8392042046a32d37cf0e04c63, type: 2}
+  floorPrefab: {fileID: 7981741694143097957, guid: 3a884a44332e25d40929799eaad6e381, type: 3}
+--- !u!1 &6743923509544370749
+GameObject:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  serializedVersion: 6
+  m_Component:
+  - component: {fileID: 7784592585474095672}
+  m_Layer: 0
+  m_Name: FloorGroup
+  m_TagString: Untagged
+  m_Icon: {fileID: 0}
+  m_NavMeshLayer: 0
+  m_StaticEditorFlags: 0
+  m_IsActive: 1
+--- !u!4 &7784592585474095672
+Transform:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 6743923509544370749}
+  m_LocalRotation: {x: -0, y: -0, z: -0, w: 1}
+  m_LocalPosition: {x: 0, y: 0, z: 0}
+  m_LocalScale: {x: 1, y: 1, z: 1}
+  m_Children:
+  - {fileID: 1259774824615474666}
+  m_Father: {fileID: 4245375790672528523}
+  m_RootOrder: 0
+  m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}

--- a/Assets/Prefabs/Modules/module_health_increase.prefab.meta
+++ b/Assets/Prefabs/Modules/module_health_increase.prefab.meta
@@ -1,0 +1,7 @@
+fileFormatVersion: 2
+guid: bfedf127b367d9242aa64dcf160f3448
+PrefabImporter:
+  externalObjects: {}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Assets/Prefabs/Ships/Player Ships/player_medium_ship.prefab
+++ b/Assets/Prefabs/Ships/Player Ships/player_medium_ship.prefab
@@ -151,11 +151,12 @@ MonoBehaviour:
     SerializedBytes: 
     ReferencedUnityObjects:
     - {fileID: 11400000, guid: a4dfa5d3274ed674db3b5d2688a6667e, type: 2}
-    - {fileID: 11400000, guid: f4b1030f7931e2346b365ac860c456df, type: 2}
+    - {fileID: 11400000, guid: fe00e2d8392042046a32d37cf0e04c63, type: 2}
     - {fileID: 11400000, guid: 551f9815f83843c4083869b9cc522d52, type: 2}
     - {fileID: 11400000, guid: 37a8333f3d207ce4d81cb5faa19d5389, type: 2}
     - {fileID: 11400000, guid: d09395ca3ec8a454c8932acb7dd201cd, type: 2}
     - {fileID: 11400000, guid: 25fe257e6aedb34499e4dd8d81b00da7, type: 2}
+    - {fileID: 11400000, guid: f4b1030f7931e2346b365ac860c456df, type: 2}
     - {fileID: 11400000, guid: b5684e958385a254cb2c5e106aa29937, type: 2}
     - {fileID: 11400000, guid: 4c32c870bdc025a41afc515c8f6b6d93, type: 2}
     - {fileID: 11400000, guid: 4b1f7686334068249871612315de6691, type: 2}
@@ -199,9 +200,6 @@ MonoBehaviour:
       Data: 5
     - Name: 
       Entry: 10
-      Data: 1
-    - Name: 
-      Entry: 10
       Data: 6
     - Name: 
       Entry: 10
@@ -209,6 +207,9 @@ MonoBehaviour:
     - Name: 
       Entry: 10
       Data: 8
+    - Name: 
+      Entry: 10
+      Data: 9
     - Name: 
       Entry: 13
       Data: 

--- a/Assets/Scripts/Scriptables/Systems/ShipHealthIncreaseSystem.cs
+++ b/Assets/Scripts/Scriptables/Systems/ShipHealthIncreaseSystem.cs
@@ -1,0 +1,61 @@
+﻿using Celeritas.Game;
+using Celeritas.Game.Entities;
+using Celeritas.Scriptables.Interfaces;
+using Sirenix.OdinInspector;
+using UnityEngine;
+using System;
+
+namespace Celeritas.Scriptables.Systems
+{
+	/// <summary>
+	/// Increases the Hull strength(health) of the ship.
+	/// </summary>
+
+	[CreateAssetMenu(fileName = "New health Increase modifier", menuName = "Celeritas/Modifiers/Hull Strength Increase")]
+	public class ShipHealthIncreaseSystem : ModifierSystem, IEntityEffectAdded, IEntityEffectRemoved
+	{
+
+		[SerializeField, PropertyRange(0, 100), Title("Percentage to add")]
+		private float amount;
+
+		[SerializeField, PropertyRange(0, 100), Title("Percentage extra to add per level")]
+		private float amountExtraPerLevel;
+
+		/// <summary>
+		/// The amount this system modifies health quantity
+		/// </summary>
+		public float Amount { get => amount; }
+
+		/// <summary>
+		/// How much extra the health are increased per level
+		/// </summary>
+		public float AmountExtraPerLevel { get => amountExtraPerLevel; }
+
+		public override bool Stacks => true;
+
+		public override SystemTargets Targets => SystemTargets.Ship;
+
+		public override string GetTooltip(ushort level) => $"<color=green>▲</color> Increase hull strength by <color=green>{(Amount + (AmountExtraPerLevel * level)):0}%</color>.";
+
+		public void OnEntityEffectAdded(Entity entity, ushort level)
+		{
+			var ship = entity as ShipEntity;
+
+			float amountToAdd = (amount/100) + ((level * amountExtraPerLevel)/100);
+
+			ship.Health.MaxValue = Convert.ToUInt32(ship.ShipData.StartingHealth + (ship.ShipData.StartingHealth * amountToAdd));
+			Debug.Log("Changed ship health to " + ship.Health.MaxValue);
+		}
+
+		public void OnEntityEffectRemoved(Entity entity, ushort level)
+		{
+			var ship = entity as ShipEntity;
+			float shiphealth = Convert.ToSingle(ship.Health.MaxValue);
+		
+			float amountToRemove = (amount / 100) + ((level * amountExtraPerLevel) / 100);
+
+			ship.Health.MaxValue = Convert.ToUInt32(shiphealth - (ship.ShipData.StartingHealth * amountToRemove));
+			Debug.Log("Changed ship health to " + ship.Health.MaxValue);
+		}
+	}
+}

--- a/Assets/Scripts/Scriptables/Systems/ShipHealthIncreaseSystem.cs.meta
+++ b/Assets/Scripts/Scriptables/Systems/ShipHealthIncreaseSystem.cs.meta
@@ -1,0 +1,11 @@
+fileFormatVersion: 2
+guid: a484dd965beb522419eb1b5b812485c0
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 


### PR DESCRIPTION
Added Ship Hull Strength Module

## Summary
> Created module to increase the max health of the player.
> Doesn't "heal" the player so added max health will need to be healed up.

## Linked Issues
closes #44