### PR TITLE
Balance textures waves

### DIFF
--- a/Assets/GameData/Environment/asteroid_basic.asset
+++ b/Assets/GameData/Environment/asteroid_basic.asset
@@ -25,4 +25,4 @@ MonoBehaviour:
   prefab: {fileID: 2582153226312631470, guid: 772751c7f4b2ed84a85f1f1961c7098c, type: 3}
   capacityHint: 75
   useChunking: 1
-  health: 100
+  health: 35

--- a/Assets/GameData/Projectiles/projectile_laser.asset
+++ b/Assets/GameData/Projectiles/projectile_laser.asset
@@ -26,6 +26,6 @@ MonoBehaviour:
   capacityHint: 30
   useChunking: 0
   speed: 100
-  lifetime: 0.2
+  lifetime: 0.3
   damage: 5
   destroyedOnHit: 1

--- a/Assets/GameData/Weapons/weapon_autocannon.asset
+++ b/Assets/GameData/Weapons/weapon_autocannon.asset
@@ -21,7 +21,7 @@ MonoBehaviour:
     PrefabModificationsReferencedUnityObjects: []
     PrefabModifications: []
     SerializationNodes:
-    - Name: moduleLayout
+    - Name: iconLayout
       Entry: 7
       Data: 0|System.Boolean[,], mscorlib
     - Name: 
@@ -64,13 +64,16 @@ MonoBehaviour:
       Entry: 8
       Data: 
   title: Autocannon
-  capacityHint: 4
   prefab: {fileID: 1948190157008792263, guid: ce606aac3fc5c174b9ba1c5c73b3c145, type: 3}
-  icon: {fileID: 21300000, guid: 3144f6c4f2f2d704db3a0e92791b3265, type: 3}
-  description: Basic autocannon weapon.
+  capacityHint: 4
+  useChunking: 0
   size: 0
   catagory: 0
   rarity: 0
+  icon: {fileID: 21300000, guid: 3144f6c4f2f2d704db3a0e92791b3265, type: 3}
+  description: A reasonably fast firing solid projectile cannon. A good all-rounder
+    starting weapon.
+  shape: 0
   projectile: {fileID: 11400000, guid: 341054bb030d7954ea09976c07126d5b, type: 2}
   rateOfFire: 5
   charge: 0

--- a/Assets/Scripts/Game/Waves/WaveManager.cs
+++ b/Assets/Scripts/Game/Waves/WaveManager.cs
@@ -46,7 +46,7 @@ namespace Celeritas.Game
 
 			foreach (ShipData ship in NewWave)
 			{
-				var spawned = EnemyManager.Instance.SpawnShip<AIBasicChase>(ship, PlayerController.Instance.PlayerShipEntity.transform.position.RandomPointOnCircle(20f));
+				var spawned = EnemyManager.Instance.SpawnShip<AIBasicChase>(ship, PlayerController.Instance.PlayerShipEntity.transform.position.RandomPointOnCircle(55f));
 				ships[wave].Add(spawned);
 			}
 

--- a/Assets/Scripts/Game/Waves/WaveManager.cs
+++ b/Assets/Scripts/Game/Waves/WaveManager.cs
@@ -30,11 +30,23 @@ namespace Celeritas.Game
 		public static event Action OnWaveEnded;
 		public static event Action OnWaveStarted;
 
+		//[SerializeField]
+		private float MIN_TIME_BETWEEN_WAVES = 5; // for build
+		private float timeOfLastWave = 0;
+
 		/// <summary>
 		/// Start a wave.
 		/// </summary>
 		public void StartWave()
 		{
+			if (Time.time - timeOfLastWave < MIN_TIME_BETWEEN_WAVES) // todo: hide button if not usable
+			{
+				Debug.Log("StartWave button in cooldown... Active in: " + (MIN_TIME_BETWEEN_WAVES - (Time.time - timeOfLastWave))+" seconds.");
+				return;
+			}
+
+			timeOfLastWave = Time.time;
+
 			WaveActive = true;
 
 			var wave = data[waveIndex];


### PR DESCRIPTION
## Summary
This branch was initially created to create projectile differences between player and enemy projectiles, as requested in #191 , however that was dropped to perform some changes that would allow playtesting to be performed more smoothly.

A delay between wave spawns was added.
Asteroids have had their health lowered significantly.
Weapons have had their description updated to be less generic and better describe their properties.
Enemies will no longer spawn on screen when a wave is spawned.


## Linked Issues
This task primarily relates to and progresses #214 but does not close the issue.

