### PR TITLE
Low health vignette

### DIFF
--- a/Assets/Prefabs/Game/Camera/Settings.prefab
+++ b/Assets/Prefabs/Game/Camera/Settings.prefab
@@ -28,6 +28,7 @@ Transform:
   m_LocalScale: {x: 1, y: 1, z: 1}
   m_Children:
   - {fileID: 7168546434679266137}
+  - {fileID: 5385857912976245628}
   m_Father: {fileID: 0}
   m_RootOrder: 0
   m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
@@ -79,3 +80,164 @@ MonoBehaviour:
   blendDistance: 0
   weight: 1
   sharedProfile: {fileID: 11400000, guid: 10fc4df2da32a41aaa32d77bc913491c, type: 2}
+--- !u!1 &4911408777014643013
+GameObject:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  serializedVersion: 6
+  m_Component:
+  - component: {fileID: 5385857912976245628}
+  - component: {fileID: 226690503173609295}
+  - component: {fileID: 8813669304308284252}
+  - component: {fileID: 4210258547385732026}
+  m_Layer: 0
+  m_Name: Post-Processing Low Health Vignette
+  m_TagString: Untagged
+  m_Icon: {fileID: 0}
+  m_NavMeshLayer: 0
+  m_StaticEditorFlags: 0
+  m_IsActive: 1
+--- !u!4 &5385857912976245628
+Transform:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 4911408777014643013}
+  m_LocalRotation: {x: -0, y: -0, z: -0, w: 1}
+  m_LocalPosition: {x: -3.8701406, y: 5.025032, z: -46.97198}
+  m_LocalScale: {x: 1, y: 1, z: 1}
+  m_Children: []
+  m_Father: {fileID: 1764990478256428806}
+  m_RootOrder: 1
+  m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
+--- !u!114 &226690503173609295
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 4911408777014643013}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: 172515602e62fb746b5d573b38a5fe58, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
+  isGlobal: 1
+  priority: 0
+  blendDistance: 0
+  weight: 0.421
+  sharedProfile: {fileID: 11400000, guid: e9d70c3a13d64a54ebc00ce97fed66a0, type: 2}
+--- !u!114 &8813669304308284252
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 4911408777014643013}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: 8e201615bf2ed9e448210a2478b1e5ec, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
+  vignetteVolume: {fileID: 226690503173609295}
+  vignetteThreshold: 15
+  sfx: {fileID: 0}
+--- !u!82 &4210258547385732026
+AudioSource:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 4911408777014643013}
+  m_Enabled: 1
+  serializedVersion: 4
+  OutputAudioMixerGroup: {fileID: 0}
+  m_audioClip: {fileID: 0}
+  m_PlayOnAwake: 1
+  m_Volume: 1
+  m_Pitch: 1
+  Loop: 0
+  Mute: 0
+  Spatialize: 0
+  SpatializePostEffects: 0
+  Priority: 128
+  DopplerLevel: 1
+  MinDistance: 1
+  MaxDistance: 500
+  Pan2D: 0
+  rolloffMode: 0
+  BypassEffects: 0
+  BypassListenerEffects: 0
+  BypassReverbZones: 0
+  rolloffCustomCurve:
+    serializedVersion: 2
+    m_Curve:
+    - serializedVersion: 3
+      time: 0
+      value: 1
+      inSlope: 0
+      outSlope: 0
+      tangentMode: 0
+      weightedMode: 0
+      inWeight: 0.33333334
+      outWeight: 0.33333334
+    - serializedVersion: 3
+      time: 1
+      value: 0
+      inSlope: 0
+      outSlope: 0
+      tangentMode: 0
+      weightedMode: 0
+      inWeight: 0.33333334
+      outWeight: 0.33333334
+    m_PreInfinity: 2
+    m_PostInfinity: 2
+    m_RotationOrder: 4
+  panLevelCustomCurve:
+    serializedVersion: 2
+    m_Curve:
+    - serializedVersion: 3
+      time: 0
+      value: 0
+      inSlope: 0
+      outSlope: 0
+      tangentMode: 0
+      weightedMode: 0
+      inWeight: 0.33333334
+      outWeight: 0.33333334
+    m_PreInfinity: 2
+    m_PostInfinity: 2
+    m_RotationOrder: 4
+  spreadCustomCurve:
+    serializedVersion: 2
+    m_Curve:
+    - serializedVersion: 3
+      time: 0
+      value: 0
+      inSlope: 0
+      outSlope: 0
+      tangentMode: 0
+      weightedMode: 0
+      inWeight: 0.33333334
+      outWeight: 0.33333334
+    m_PreInfinity: 2
+    m_PostInfinity: 2
+    m_RotationOrder: 4
+  reverbZoneMixCustomCurve:
+    serializedVersion: 2
+    m_Curve:
+    - serializedVersion: 3
+      time: 0
+      value: 1
+      inSlope: 0
+      outSlope: 0
+      tangentMode: 0
+      weightedMode: 0
+      inWeight: 0.33333334
+      outWeight: 0.33333334
+    m_PreInfinity: 2
+    m_PostInfinity: 2
+    m_RotationOrder: 4

--- a/Assets/Scenes/Main.unity
+++ b/Assets/Scenes/Main.unity
@@ -123,6 +123,11 @@ NavMeshSettings:
     debug:
       m_Flags: 0
   m_NavMeshData: {fileID: 0}
+--- !u!4 &313918563 stripped
+Transform:
+  m_CorrespondingSourceObject: {fileID: 1764990478256428806, guid: 22ae3c427efc12146b42b59c4516353d, type: 3}
+  m_PrefabInstance: {fileID: 1764990479629972339}
+  m_PrefabAsset: {fileID: 0}
 --- !u!1 &855143037
 GameObject:
   m_ObjectHideFlags: 0
@@ -4983,6 +4988,68 @@ MonoBehaviour:
   m_Script: {fileID: 11500000, guid: afb911a6128e9564d8c7ae860fc9abd9, type: 3}
   m_Name: 
   m_EditorClassIdentifier: 
+--- !u!1 &1671148691
+GameObject:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  serializedVersion: 6
+  m_Component:
+  - component: {fileID: 1671148692}
+  - component: {fileID: 1671148693}
+  - component: {fileID: 1671148694}
+  m_Layer: 0
+  m_Name: Post-Processing Low Health Vignette
+  m_TagString: Untagged
+  m_Icon: {fileID: 0}
+  m_NavMeshLayer: 0
+  m_StaticEditorFlags: 0
+  m_IsActive: 1
+--- !u!4 &1671148692
+Transform:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 1671148691}
+  m_LocalRotation: {x: -0, y: -0, z: -0, w: 1}
+  m_LocalPosition: {x: -3.8701406, y: 5.025032, z: -46.97198}
+  m_LocalScale: {x: 1, y: 1, z: 1}
+  m_Children: []
+  m_Father: {fileID: 313918563}
+  m_RootOrder: 1
+  m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
+--- !u!114 &1671148693
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 1671148691}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: 172515602e62fb746b5d573b38a5fe58, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
+  isGlobal: 1
+  priority: 0
+  blendDistance: 0
+  weight: 1
+  sharedProfile: {fileID: 11400000, guid: e9d70c3a13d64a54ebc00ce97fed66a0, type: 2}
+--- !u!114 &1671148694
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 1671148691}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: 8e201615bf2ed9e448210a2478b1e5ec, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
+  vignetteVolume: {fileID: 1671148693}
 --- !u!1 &1843779020
 GameObject:
   m_ObjectHideFlags: 0
@@ -5083,6 +5150,10 @@ PrefabInstance:
   m_Modification:
     m_TransformParent: {fileID: 0}
     m_Modifications:
+    - target: {fileID: 627083987495544363, guid: 22ae3c427efc12146b42b59c4516353d, type: 3}
+      propertyPath: m_Enabled
+      value: 1
+      objectReference: {fileID: 0}
     - target: {fileID: 1764990478256428806, guid: 22ae3c427efc12146b42b59c4516353d, type: 3}
       propertyPath: m_RootOrder
       value: 1
@@ -5268,6 +5339,38 @@ PrefabInstance:
     - target: {fileID: 5641295164690157525, guid: 3873a34f86c4ca5439c25133c6908095, type: 3}
       propertyPath: m_AnchorMax.y
       value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 5641295164851739855, guid: 3873a34f86c4ca5439c25133c6908095, type: 3}
+      propertyPath: m_Value
+      value: 0.602
+      objectReference: {fileID: 0}
+    - target: {fileID: 5641295164851739855, guid: 3873a34f86c4ca5439c25133c6908095, type: 3}
+      propertyPath: m_OnValueChanged.m_PersistentCalls.m_Calls.Array.size
+      value: 1
+      objectReference: {fileID: 0}
+    - target: {fileID: 5641295164851739855, guid: 3873a34f86c4ca5439c25133c6908095, type: 3}
+      propertyPath: m_OnValueChanged.m_PersistentCalls.m_Calls.Array.data[0].m_Mode
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 5641295164851739855, guid: 3873a34f86c4ca5439c25133c6908095, type: 3}
+      propertyPath: m_OnValueChanged.m_PersistentCalls.m_Calls.Array.data[0].m_Target
+      value: 
+      objectReference: {fileID: 1671148694}
+    - target: {fileID: 5641295164851739855, guid: 3873a34f86c4ca5439c25133c6908095, type: 3}
+      propertyPath: m_OnValueChanged.m_PersistentCalls.m_Calls.Array.data[0].m_CallState
+      value: 2
+      objectReference: {fileID: 0}
+    - target: {fileID: 5641295164851739855, guid: 3873a34f86c4ca5439c25133c6908095, type: 3}
+      propertyPath: m_OnValueChanged.m_PersistentCalls.m_Calls.Array.data[0].m_MethodName
+      value: onHealthChange
+      objectReference: {fileID: 0}
+    - target: {fileID: 5641295164851739855, guid: 3873a34f86c4ca5439c25133c6908095, type: 3}
+      propertyPath: m_OnValueChanged.m_PersistentCalls.m_Calls.Array.data[0].m_TargetAssemblyTypeName
+      value: LowHealthVignette, Assembly-CSharp
+      objectReference: {fileID: 0}
+    - target: {fileID: 5641295164851739855, guid: 3873a34f86c4ca5439c25133c6908095, type: 3}
+      propertyPath: m_OnValueChanged.m_PersistentCalls.m_Calls.Array.data[0].m_Arguments.m_ObjectArgumentAssemblyTypeName
+      value: UnityEngine.Object, UnityEngine
       objectReference: {fileID: 0}
     - target: {fileID: 5641295164953991232, guid: 3873a34f86c4ca5439c25133c6908095, type: 3}
       propertyPath: m_Pivot.x

--- a/Assets/Scenes/Main.unity
+++ b/Assets/Scenes/Main.unity
@@ -123,11 +123,6 @@ NavMeshSettings:
     debug:
       m_Flags: 0
   m_NavMeshData: {fileID: 0}
---- !u!4 &313918563 stripped
-Transform:
-  m_CorrespondingSourceObject: {fileID: 1764990478256428806, guid: 22ae3c427efc12146b42b59c4516353d, type: 3}
-  m_PrefabInstance: {fileID: 1764990479629972339}
-  m_PrefabAsset: {fileID: 0}
 --- !u!1 &855143037
 GameObject:
   m_ObjectHideFlags: 0
@@ -4988,68 +4983,17 @@ MonoBehaviour:
   m_Script: {fileID: 11500000, guid: afb911a6128e9564d8c7ae860fc9abd9, type: 3}
   m_Name: 
   m_EditorClassIdentifier: 
---- !u!1 &1671148691
-GameObject:
-  m_ObjectHideFlags: 0
-  m_CorrespondingSourceObject: {fileID: 0}
-  m_PrefabInstance: {fileID: 0}
-  m_PrefabAsset: {fileID: 0}
-  serializedVersion: 6
-  m_Component:
-  - component: {fileID: 1671148692}
-  - component: {fileID: 1671148693}
-  - component: {fileID: 1671148694}
-  m_Layer: 0
-  m_Name: Post-Processing Low Health Vignette
-  m_TagString: Untagged
-  m_Icon: {fileID: 0}
-  m_NavMeshLayer: 0
-  m_StaticEditorFlags: 0
-  m_IsActive: 1
---- !u!4 &1671148692
-Transform:
-  m_ObjectHideFlags: 0
-  m_CorrespondingSourceObject: {fileID: 0}
-  m_PrefabInstance: {fileID: 0}
-  m_PrefabAsset: {fileID: 0}
-  m_GameObject: {fileID: 1671148691}
-  m_LocalRotation: {x: -0, y: -0, z: -0, w: 1}
-  m_LocalPosition: {x: -3.8701406, y: 5.025032, z: -46.97198}
-  m_LocalScale: {x: 1, y: 1, z: 1}
-  m_Children: []
-  m_Father: {fileID: 313918563}
-  m_RootOrder: 1
-  m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
---- !u!114 &1671148693
+--- !u!114 &1671148694 stripped
 MonoBehaviour:
-  m_ObjectHideFlags: 0
-  m_CorrespondingSourceObject: {fileID: 0}
-  m_PrefabInstance: {fileID: 0}
+  m_CorrespondingSourceObject: {fileID: 8813669304308284252, guid: 22ae3c427efc12146b42b59c4516353d, type: 3}
+  m_PrefabInstance: {fileID: 1764990479629972339}
   m_PrefabAsset: {fileID: 0}
-  m_GameObject: {fileID: 1671148691}
-  m_Enabled: 1
-  m_EditorHideFlags: 0
-  m_Script: {fileID: 11500000, guid: 172515602e62fb746b5d573b38a5fe58, type: 3}
-  m_Name: 
-  m_EditorClassIdentifier: 
-  isGlobal: 1
-  priority: 0
-  blendDistance: 0
-  weight: 1
-  sharedProfile: {fileID: 11400000, guid: e9d70c3a13d64a54ebc00ce97fed66a0, type: 2}
---- !u!114 &1671148694
-MonoBehaviour:
-  m_ObjectHideFlags: 0
-  m_CorrespondingSourceObject: {fileID: 0}
-  m_PrefabInstance: {fileID: 0}
-  m_PrefabAsset: {fileID: 0}
-  m_GameObject: {fileID: 1671148691}
+  m_GameObject: {fileID: 0}
   m_Enabled: 1
   m_EditorHideFlags: 0
   m_Script: {fileID: 11500000, guid: 8e201615bf2ed9e448210a2478b1e5ec, type: 3}
   m_Name: 
   m_EditorClassIdentifier: 
-  vignetteVolume: {fileID: 1671148693}
 --- !u!1 &1843779020
 GameObject:
   m_ObjectHideFlags: 0

--- a/Assets/Scenes/Main.unity
+++ b/Assets/Scenes/Main.unity
@@ -5094,6 +5094,10 @@ PrefabInstance:
   m_Modification:
     m_TransformParent: {fileID: 0}
     m_Modifications:
+    - target: {fileID: 226690503173609295, guid: 22ae3c427efc12146b42b59c4516353d, type: 3}
+      propertyPath: weight
+      value: 1
+      objectReference: {fileID: 0}
     - target: {fileID: 627083987495544363, guid: 22ae3c427efc12146b42b59c4516353d, type: 3}
       propertyPath: m_Enabled
       value: 1

--- a/Assets/Scripts/Game/LowHealthVignette.cs
+++ b/Assets/Scripts/Game/LowHealthVignette.cs
@@ -39,7 +39,7 @@ public class LowHealthVignette : MonoBehaviour
 			playerShip = PlayerController.Instance.PlayerShipEntity;
 		}
 		temp = Math.Abs(Math.Sin(Time.time));
-		pulse = 1f + (float)temp;
+		pulse = (float)temp;
 		pulseIntensity.postExposure.value = pulse;
 	}
 

--- a/Assets/Scripts/Game/LowHealthVignette.cs
+++ b/Assets/Scripts/Game/LowHealthVignette.cs
@@ -1,0 +1,52 @@
+using Celeritas.Game.Controllers;
+using Celeritas.Game.Entities;
+using System.Collections;
+using System.Collections.Generic;
+using UnityEngine;
+using UnityEngine.Rendering;
+
+public class LowHealthVignette : MonoBehaviour
+{
+	[SerializeField]
+	private Volume vignetteVolume;
+	private ShipEntity playerShip;
+	//Update() because Awake() was giving nullrefs :(
+	private void Update()
+	{
+		// if just starting, link stationary stat bars to PlayerShip
+		if (playerShip == null && PlayerController.Instance != null)
+		{
+			playerShip = PlayerController.Instance.PlayerShipEntity;
+			onHealthChange(1f);
+		}
+
+	}
+
+	private float intensity;
+	private float maxHP;
+	// Is sent current hp  from the HP bar. We ignore this, since we're using values
+	// from the playerShip entity instead.
+	// Intensity needed is calculated, then the vignette modified.
+	public void onHealthChange(float hp)
+	{
+		intensity = calculateIntensity();
+		modifyVignetteIntensity();
+	}
+
+	// Currently a simple 1:1 HP-goes-lower-intensity-goes-higher calculation.
+	// This will almost certainally change, which is why it's a seperate function.
+	private float calculatedValue;
+	private float calculateIntensity()
+	{
+		calculatedValue = 1 - ((float) playerShip.Health.CurrentValue / (float) playerShip.Health.MaxValue);
+		//calculatedValue = (float) PlayerController.Instance.PlayerShipEntity.Health.CurrentValue / (float) PlayerController.Instance.PlayerShipEntity.Health.MaxValue; //for testing!
+		return calculatedValue;
+	}
+
+	private void modifyVignetteIntensity()
+	{
+		vignetteVolume.weight = intensity;
+	}
+
+
+}

--- a/Assets/Scripts/Game/LowHealthVignette.cs
+++ b/Assets/Scripts/Game/LowHealthVignette.cs
@@ -21,8 +21,9 @@ public class LowHealthVignette : MonoBehaviour
 		vignetteVolume.profile.TryGet(out pulseIntensity);
 		if (pulseIntensity == null)
 		{
-			Debug.Log("pulsecolour null :(");
+			Debug.Log("pulseIntensity null :(");
 		}
+		modifyVignetteIntensity();
 	}
 
 
@@ -36,13 +37,14 @@ public class LowHealthVignette : MonoBehaviour
 		if (playerShip == null && PlayerController.Instance != null)
 		{
 			playerShip = PlayerController.Instance.PlayerShipEntity;
-			onHealthChange(1f);
 		}
 		temp = Math.Abs(Math.Sin(Time.time));
-		pulse = 1.5f + (float)temp;
+		pulse = 1f + (float)temp;
 		pulseIntensity.postExposure.value = pulse;
 	}
 
+	[SerializeField]
+	private float vignetteThreshold;
 	private float intensity;
 	/// <summary>
 	/// Modifies the low-health vignette when HP changes.
@@ -60,25 +62,34 @@ public class LowHealthVignette : MonoBehaviour
 	// Currently a simple 1:1 HP-goes-lower-intensity-goes-higher calculation.
 	// This will almost certainally change, which is why it's a seperate function.
 	private float calculatedValue;
+	private float shipHealthPercentage;
 	private float calculateIntensity()
 	{
-		calculatedValue = 1 - ((float) playerShip.Health.CurrentValue / (float) playerShip.Health.MaxValue);
+		shipHealthPercentage = ((float)playerShip.Health.CurrentValue / (float)playerShip.Health.MaxValue);
+		calculatedValue = 1 - shipHealthPercentage;
+		shipHealthPercentage *= 100;
 		//calculatedValue = (float) PlayerController.Instance.PlayerShipEntity.Health.CurrentValue / (float) PlayerController.Instance.PlayerShipEntity.Health.MaxValue; //for testing!
 		return calculatedValue;
 	}
 
 	[SerializeField]
 	private AudioClip sfx;
-	[SerializeField]
-	private float sfxThreshold;
+
 	private void modifyVignetteIntensity()
 	{
-		vignetteVolume.weight = intensity;
-
-		if (intensity < sfxThreshold)
+		if (shipHealthPercentage < vignetteThreshold)
 		{
-			audio.PlayOneShot(sfx);
+			vignetteVolume.weight = intensity;
+			if (sfx != null)
+			{
+				audio.PlayOneShot(sfx);
+			}
 		}
+		else
+		{
+			vignetteVolume.weight = 0f;  //in case you come into the scene with something weird, turns the vignette off again
+		}
+
 	}
 
 

--- a/Assets/Scripts/Game/LowHealthVignette.cs.meta
+++ b/Assets/Scripts/Game/LowHealthVignette.cs.meta
@@ -1,0 +1,11 @@
+fileFormatVersion: 2
+guid: 8e201615bf2ed9e448210a2478b1e5ec
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Assets/Settings/Rendering/LowHealthVignette.asset
+++ b/Assets/Settings/Rendering/LowHealthVignette.asset
@@ -16,7 +16,7 @@ MonoBehaviour:
   m_AdvancedMode: 0
   postExposure:
     m_OverrideState: 1
-    m_Value: 2.11
+    m_Value: 1.44
   contrast:
     m_OverrideState: 0
     m_Value: 0
@@ -63,7 +63,7 @@ MonoBehaviour:
     m_Value: {x: 0.5, y: 0.5}
   intensity:
     m_OverrideState: 1
-    m_Value: 0.684
+    m_Value: 0.286
     min: 0
     max: 1
   smoothness:

--- a/Assets/Settings/Rendering/LowHealthVignette.asset
+++ b/Assets/Settings/Rendering/LowHealthVignette.asset
@@ -1,0 +1,121 @@
+%YAML 1.1
+%TAG !u! tag:unity3d.com,2011:
+--- !u!114 &-7442036142559521516
+MonoBehaviour:
+  m_ObjectHideFlags: 3
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 0}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: 899c54efeace73346a0a16faa3afe726, type: 3}
+  m_Name: Vignette
+  m_EditorClassIdentifier: 
+  active: 1
+  m_AdvancedMode: 0
+  color:
+    m_OverrideState: 1
+    m_Value: {r: 0.7075472, g: 0, b: 0, a: 1}
+    hdr: 0
+    showAlpha: 0
+    showEyeDropper: 1
+  center:
+    m_OverrideState: 1
+    m_Value: {x: 0.5, y: 0.5}
+  intensity:
+    m_OverrideState: 1
+    m_Value: 0.684
+    min: 0
+    max: 1
+  smoothness:
+    m_OverrideState: 1
+    m_Value: 0.946
+    min: 0.01
+    max: 1
+  rounded:
+    m_OverrideState: 0
+    m_Value: 0
+--- !u!114 &-4685067167953084816
+MonoBehaviour:
+  m_ObjectHideFlags: 3
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 0}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: 29fa0085f50d5e54f8144f766051a691, type: 3}
+  m_Name: FilmGrain
+  m_EditorClassIdentifier: 
+  active: 1
+  m_AdvancedMode: 0
+  type:
+    m_OverrideState: 1
+    m_Value: 3
+  intensity:
+    m_OverrideState: 1
+    m_Value: 0.685
+    min: 0
+    max: 1
+  response:
+    m_OverrideState: 1
+    m_Value: 0.862
+    min: 0
+    max: 1
+  texture:
+    m_OverrideState: 0
+    m_Value: {fileID: 0}
+--- !u!114 &11400000
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 0}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: d7fd9488000d3734a9e00ee676215985, type: 3}
+  m_Name: LowHealthVignette
+  m_EditorClassIdentifier: 
+  components:
+  - {fileID: -7442036142559521516}
+  - {fileID: 1062644214807295403}
+  - {fileID: -4685067167953084816}
+--- !u!114 &1062644214807295403
+MonoBehaviour:
+  m_ObjectHideFlags: 3
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 0}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: c5e1dc532bcb41949b58bc4f2abfbb7e, type: 3}
+  m_Name: LensDistortion
+  m_EditorClassIdentifier: 
+  active: 1
+  m_AdvancedMode: 0
+  intensity:
+    m_OverrideState: 1
+    m_Value: 0.33
+    min: -1
+    max: 1
+  xMultiplier:
+    m_OverrideState: 0
+    m_Value: 1
+    min: 0
+    max: 1
+  yMultiplier:
+    m_OverrideState: 0
+    m_Value: 1
+    min: 0
+    max: 1
+  center:
+    m_OverrideState: 0
+    m_Value: {x: 0.5, y: 0.5}
+  scale:
+    m_OverrideState: 0
+    m_Value: 1
+    min: 0.01
+    max: 5

--- a/Assets/Settings/Rendering/LowHealthVignette.asset
+++ b/Assets/Settings/Rendering/LowHealthVignette.asset
@@ -15,8 +15,8 @@ MonoBehaviour:
   active: 1
   m_AdvancedMode: 0
   postExposure:
-    m_OverrideState: 0
-    m_Value: 0
+    m_OverrideState: 1
+    m_Value: 2.11
   contrast:
     m_OverrideState: 0
     m_Value: 0
@@ -120,6 +120,7 @@ MonoBehaviour:
   - {fileID: -7442036142559521516}
   - {fileID: 1062644214807295403}
   - {fileID: -4685067167953084816}
+  - {fileID: -8679310933745444302}
 --- !u!114 &1062644214807295403
 MonoBehaviour:
   m_ObjectHideFlags: 3

--- a/Assets/Settings/Rendering/LowHealthVignette.asset
+++ b/Assets/Settings/Rendering/LowHealthVignette.asset
@@ -1,5 +1,43 @@
 %YAML 1.1
 %TAG !u! tag:unity3d.com,2011:
+--- !u!114 &-8679310933745444302
+MonoBehaviour:
+  m_ObjectHideFlags: 3
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 0}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: 66f335fb1ffd8684294ad653bf1c7564, type: 3}
+  m_Name: ColorAdjustments
+  m_EditorClassIdentifier: 
+  active: 1
+  m_AdvancedMode: 0
+  postExposure:
+    m_OverrideState: 0
+    m_Value: 0
+  contrast:
+    m_OverrideState: 0
+    m_Value: 0
+    min: -100
+    max: 100
+  colorFilter:
+    m_OverrideState: 0
+    m_Value: {r: 1, g: 1, b: 1, a: 1}
+    hdr: 1
+    showAlpha: 0
+    showEyeDropper: 1
+  hueShift:
+    m_OverrideState: 0
+    m_Value: 0
+    min: -180
+    max: 180
+  saturation:
+    m_OverrideState: 0
+    m_Value: 0
+    min: -100
+    max: 100
 --- !u!114 &-7442036142559521516
 MonoBehaviour:
   m_ObjectHideFlags: 3

--- a/Assets/Settings/Rendering/LowHealthVignette.asset.meta
+++ b/Assets/Settings/Rendering/LowHealthVignette.asset.meta
@@ -1,0 +1,8 @@
+fileFormatVersion: 2
+guid: e9d70c3a13d64a54ebc00ce97fed66a0
+NativeFormatImporter:
+  externalObjects: {}
+  mainObjectFileID: 11400000
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 


### PR DESCRIPTION
## Summary
Adds a low health vignette! Becomes more intense the lower your health.
Includes pulsing effect and space for a SFX, though no SFX has been added.
Also adds a threshold percentage, so it only shows up when health is less than that.  Have set it to 15% as instructed but I feel like that's too low?  IDK that's a balance change, not my area. (I'd do 25% at least though.)

## Linked Issues
Closes #248
