### PR TITLE
Player collision damage reduction

### DIFF
--- a/Assets/Scripts/Game/Entities/Asteroid.cs
+++ b/Assets/Scripts/Game/Entities/Asteroid.cs
@@ -23,6 +23,8 @@ namespace Celeritas.Game.Entities
 
 		private EntityStatBar health;
 
+		public EntityStatBar Health { get => health; }
+
 		public AsteroidData AsteroidData { get; private set; }
 
 		public Rigidbody2D Rigidbody { get; private set; }

--- a/Assets/Scripts/Game/Entities/ITractorBeamTarget.cs
+++ b/Assets/Scripts/Game/Entities/ITractorBeamTarget.cs
@@ -1,4 +1,5 @@
-﻿using System;
+﻿using Celeritas.UI;
+using System;
 using System.Collections.Generic;
 using System.Linq;
 using System.Text;
@@ -13,6 +14,8 @@ namespace Celeritas.Game.Entities
 	interface ITractorBeamTarget
 	{
 		public Rigidbody2D Rigidbody { get; }
+
+		public EntityStatBar Health { get; }
 
 	}
 }

--- a/Assets/Scripts/Game/Entities/ShipEntity.cs
+++ b/Assets/Scripts/Game/Entities/ShipEntity.cs
@@ -230,7 +230,7 @@ namespace Celeritas.Game.Entities
 		/// <param name="damage">The amount of damage to take.</param>
 		public override void TakeDamage(Entity attackingEntity, float damage)
 		{
-			if (attackingEntity is ProjectileEntity || attackingEntity is ShipEntity || attackingEntity == this)
+			if (attackingEntity is ProjectileEntity || attackingEntity is ShipEntity || attackingEntity is Asteroid || attackingEntity == this)
 			{
 				base.TakeDamage(attackingEntity);
 

--- a/Assets/Scripts/Game/Entity.cs
+++ b/Assets/Scripts/Game/Entity.cs
@@ -421,8 +421,11 @@ namespace Celeritas.Game
 			// by default, entities have no health, so this does nothing. Will be overridden by children.
 		}
 
-		protected float collisionDamageMultiplier = 5;
-		protected float playerCollisionDamageMultiplier = 0.15f;
+		protected float collisionDamageMultiplier = 5; // multiplier for all collision damage
+		protected float playerCollisionDamageMultiplier = 0.15f; // multiplier for reducing player damage
+
+		// max damage player can take from 1 collision, as a fraction of their health
+		protected float playerCollisionDamageCapMultiplier = 0.15f; 
 
 		/// <summary>
 		/// Damages other entity with collision damage. Damage self with 50% of damage, too.
@@ -449,8 +452,14 @@ namespace Celeritas.Game
 				float force = velocityDifference * averageMass * multiplier;
 				if ((int)force == 0)
 					return;
-				
-				other.TakeDamage(this, (int)force);
+
+				if (other.PlayerShip && force > (target.Health.MaxValue * playerCollisionDamageCapMultiplier))
+				{
+					//Debug.Log($"{force} exceeds max of {playerCollisionDamageCapMultiplier} * {target.Health.MaxValue}, so will be reduced to {target.Health.MaxValue * playerCollisionDamageCapMultiplier}");
+					force = target.Health.MaxValue * playerCollisionDamageCapMultiplier;
+				}
+
+				other.TakeDamage(this, force);
 			}
 		}
 

--- a/Assets/Scripts/Game/Entity.cs
+++ b/Assets/Scripts/Game/Entity.cs
@@ -422,7 +422,7 @@ namespace Celeritas.Game
 		}
 
 		protected float collisionDamageMultiplier = 10;
-		protected float playerCollisionDamageMultiplier = 0.1f;
+		protected float playerCollisionDamageMultiplier = 0.15f;
 
 		/// <summary>
 		/// Damages other entity with collision damage. Damage self with 50% of damage, too.
@@ -443,7 +443,7 @@ namespace Celeritas.Game
 					multiplier *= playerCollisionDamageMultiplier;
 
 				float velocityDifference = Mathf.Abs((ownerRigidBody.velocity - target.Rigidbody.velocity).magnitude); // should always be positive but just in case
-				float averageMass = (ownerRigidBody.mass + target.Rigidbody.mass / 2);
+				float averageMass = ((ownerRigidBody.mass + target.Rigidbody.mass) / 2);
 
 				// momentum is velocity * mass
 				float force = velocityDifference * averageMass * multiplier;

--- a/Assets/Scripts/Game/Entity.cs
+++ b/Assets/Scripts/Game/Entity.cs
@@ -451,8 +451,6 @@ namespace Celeritas.Game
 					return;
 				
 				other.TakeDamage(this, (int)force);
-				Debug.Log($"{other} taking {force} damage, (multiplier = {multiplier}");
-
 
 				// take half damage yourself
 				// removing for now, as unsure if it is necessary

--- a/Assets/Scripts/Game/Entity.cs
+++ b/Assets/Scripts/Game/Entity.cs
@@ -428,7 +428,7 @@ namespace Celeritas.Game
 		protected float playerCollisionDamageCapMultiplier = 0.15f; 
 
 		/// <summary>
-		/// Damages other entity with collision damage. Damage self with 50% of damage, too.
+		/// Damages other entity with collision damage.
 		/// Designed to be put into OnEntityHit if you want an entity to apply collision damage.
 		/// </summary>
 		/// <param name="ownerRigidBody">the rigidBody of 'this'.</param>

--- a/Assets/Scripts/Game/Entity.cs
+++ b/Assets/Scripts/Game/Entity.cs
@@ -422,6 +422,7 @@ namespace Celeritas.Game
 		}
 
 		protected float collisionDamageMultiplier = 10;
+		protected float playerCollisionDamageMultiplier = 0.15f;
 
 		/// <summary>
 		/// Damages other entity with collision damage. Damage self with 50% of damage, too.
@@ -434,15 +435,34 @@ namespace Celeritas.Game
 			// calculate collision damage
 			if (other is ITractorBeamTarget)
 			{
+				ITractorBeamTarget target = other as ITractorBeamTarget;
+
+				// other take damage
+				float multiplier = collisionDamageMultiplier;
+				if (other.PlayerShip)
+					multiplier *= playerCollisionDamageMultiplier;
+
+				float velocityDifference = Mathf.Abs((ownerRigidBody.velocity - target.Rigidbody.velocity).magnitude); // should always be positive but just in case
+				float averageMass = (ownerRigidBody.mass + target.Rigidbody.mass / 2);
+
 				// momentum is velocity * mass
-				float force = ownerRigidBody.velocity.magnitude * ownerRigidBody.mass * collisionDamageMultiplier;
+				float force = velocityDifference * averageMass * multiplier;
 				if ((int)force == 0)
 					return;
 				
 				other.TakeDamage(this, (int)force);
+				Debug.Log($"{other} taking {force} damage, (multiplier = {multiplier}");
+
 
 				// take half damage yourself
-				TakeDamage(this, (int)force / 2);
+				// removing for now, as unsure if it is necessary
+				/*if (this.PlayerShip)
+					multiplier = collisionDamageMultiplier * playerCollisionDamageMultiplier;
+				else
+					multiplier = collisionDamageMultiplier;
+
+				force = velocityDifference * ownerRigidBody.mass * multiplier;
+				TakeDamage(this, (int)force / 2);*/
 			}
 		}
 

--- a/Assets/Scripts/Game/Entity.cs
+++ b/Assets/Scripts/Game/Entity.cs
@@ -421,7 +421,7 @@ namespace Celeritas.Game
 			// by default, entities have no health, so this does nothing. Will be overridden by children.
 		}
 
-		protected float collisionDamageMultiplier = 10;
+		protected float collisionDamageMultiplier = 5;
 		protected float playerCollisionDamageMultiplier = 0.15f;
 
 		/// <summary>

--- a/Assets/Scripts/Game/Entity.cs
+++ b/Assets/Scripts/Game/Entity.cs
@@ -422,7 +422,7 @@ namespace Celeritas.Game
 		}
 
 		protected float collisionDamageMultiplier = 10;
-		protected float playerCollisionDamageMultiplier = 0.15f;
+		protected float playerCollisionDamageMultiplier = 0.1f;
 
 		/// <summary>
 		/// Damages other entity with collision damage. Damage self with 50% of damage, too.
@@ -451,16 +451,6 @@ namespace Celeritas.Game
 					return;
 				
 				other.TakeDamage(this, (int)force);
-
-				// take half damage yourself
-				// removing for now, as unsure if it is necessary
-				/*if (this.PlayerShip)
-					multiplier = collisionDamageMultiplier * playerCollisionDamageMultiplier;
-				else
-					multiplier = collisionDamageMultiplier;
-
-				force = velocityDifference * ownerRigidBody.mass * multiplier;
-				TakeDamage(this, (int)force / 2);*/
 			}
 		}
 


### PR DESCRIPTION
## Summary
* implemented damage cap, so collisions cannot do more than 15% of the player's health at any one time (exposed Health on ITractorBeamTargets to do this)
* Player ship now takes 0.15 x the amount of damage from all collisions
* cleaned up the collision logic, so it factors velocity difference and average mass of the two colliding objects
* Fixed ships not directly taking damage from asteroid collisions
* All collision damage reduced by 50%

## Linked Issues
closes #328

## Screenshots

https://user-images.githubusercontent.com/19755210/135970726-e39fcbab-315b-4b17-991e-437ee4456e96.mp4


