### PR TITLE
Fixed acid projectile module bug

### DIFF
--- a/Assets/Prefabs/Modules/module_acidic_projectiles.prefab
+++ b/Assets/Prefabs/Modules/module_acidic_projectiles.prefab
@@ -64,7 +64,7 @@ MonoBehaviour:
   timeToPlayOnDestroyEffect: 0
   onHitEffectPrefab: {fileID: 0}
   timeToPlayOnHitEffect: 0
-  level: 1
+  level: 0
   hasShipEffects: 0
   shipEffects: []
   hasShipWeaponEffects: 0

--- a/Assets/Prefabs/Ships/Player Ships/player_medium_ship_debug.prefab
+++ b/Assets/Prefabs/Ships/Player Ships/player_medium_ship_debug.prefab
@@ -149,7 +149,6 @@ MonoBehaviour:
     - {fileID: 11400000, guid: a4dfa5d3274ed674db3b5d2688a6667e, type: 2}
     - {fileID: 11400000, guid: 6667795d5cd63e04eb980c3115a6e79f, type: 2}
     - {fileID: 11400000, guid: 551f9815f83843c4083869b9cc522d52, type: 2}
-    - {fileID: 11400000, guid: 700a3d56c6e840f4f982ce2b75fbd807, type: 2}
     - {fileID: 11400000, guid: 37a8333f3d207ce4d81cb5faa19d5389, type: 2}
     - {fileID: 11400000, guid: d09395ca3ec8a454c8932acb7dd201cd, type: 2}
     - {fileID: 11400000, guid: 25fe257e6aedb34499e4dd8d81b00da7, type: 2}
@@ -188,13 +187,16 @@ MonoBehaviour:
       Data: 2
     - Name: 
       Entry: 10
+      Data: 1
+    - Name: 
+      Entry: 10
       Data: 3
     - Name: 
       Entry: 10
-      Data: 4
+      Data: 1
     - Name: 
       Entry: 10
-      Data: 1
+      Data: 4
     - Name: 
       Entry: 10
       Data: 5
@@ -210,9 +212,6 @@ MonoBehaviour:
     - Name: 
       Entry: 10
       Data: 9
-    - Name: 
-      Entry: 10
-      Data: 10
     - Name: 
       Entry: 13
       Data: 


### PR DESCRIPTION
## Summary
Fixed bug with acid projectile module starting on level 2.
This also resolves the module duplication bug and damage bug.

## Linked Issues
closes #379
