### PR TITLE
Resizes tooltip title text if it's too long for the area.

### DIFF
--- a/Assets/Scenes/Persistent.unity
+++ b/Assets/Scenes/Persistent.unity
@@ -2060,7 +2060,7 @@ RectTransform:
   m_RootOrder: 0
   m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
   m_AnchorMin: {x: 0, y: 1}
-  m_AnchorMax: {x: 1, y: 1}
+  m_AnchorMax: {x: 0.6, y: 1}
   m_AnchoredPosition: {x: 16, y: 0}
   m_SizeDelta: {x: -16, y: 48}
   m_Pivot: {x: 0, y: 1}
@@ -2114,9 +2114,9 @@ MonoBehaviour:
   m_fontSize: 26
   m_fontSizeBase: 26
   m_fontWeight: 400
-  m_enableAutoSizing: 0
+  m_enableAutoSizing: 1
   m_fontSizeMin: 18
-  m_fontSizeMax: 72
+  m_fontSizeMax: 26
   m_fontStyle: 0
   m_HorizontalAlignment: 1
   m_VerticalAlignment: 256


### PR DESCRIPTION
## Summary
- Shortened the title textbox size so it doesn't overlap the icons
- Made the font size dynamic, with a max size of the current font size

## Linked Issues
Closes #401

## Screenshots (optional)
