### PR TITLE
Overlapping options text fix.

### DIFF
--- a/Assets/Scripts/UI/DialogueManager.cs
+++ b/Assets/Scripts/UI/DialogueManager.cs
@@ -114,7 +114,9 @@ namespace Celeritas.UI
 
 		private void CreateOption(string text, int index, OptionType type, Action<int> callback)
 		{
-			var option = Instantiate(dialogueOptionPrefab, dialogueOptionParent).GetComponent<DialogueOption>();
+			GameObject prefab = Instantiate(dialogueOptionPrefab);
+			prefab.transform.SetParent(dialogueOptionParent, false);
+			var option = prefab.GetComponent<DialogueOption>();
 			option.SetOptionType(type);
 			option.Text = text;
 			option.OnClicked += () =>


### PR DESCRIPTION
(Hopefully!)

## Summary
Changes how the options prefab is instantiated - instantiates, then sets the parent, rather than all in one.  Why this fixes things I have NO IDEA but it's [recommended in the Unity docs](https://docs.unity3d.com/Packages/com.unity.ugui@1.0/manual/HOWTO-UICreateFromScripting.html#instantiating-the-ui-element), which is why I tried it to begin with.

Has been tested, and confirmed to at least _reduce_ the number of overlapping instances; I was getting them almost every time and now I haven't been getting them at all.  But there may still be edge cases out there, since I have no idea why the fix actually works.

## Linked Issues
Closes #403
